### PR TITLE
Completed task: "Number of Issues Opened Per Contributor"

### DIFF
--- a/git-technetium/public/index.html
+++ b/git-technetium/public/index.html
@@ -14,6 +14,7 @@
         <script src="scripts/controllers/issuesController.js"></script>
         <script src="scripts/controllers/issuesOpenedController.js"></script>
         <script src="scripts/factories/issuesFactory.js"></script>
+        <script src="scripts/factories/issuesOpenedFactory.js"></script>
     </head>
 
     <body>

--- a/git-technetium/public/index.html
+++ b/git-technetium/public/index.html
@@ -12,6 +12,7 @@
         <script src="scripts/controllers/gitController.js"></script>
         <script src="scripts/controllers/basicController.js"></script>
         <script src="scripts/controllers/issuesController.js"></script>
+        <script src="scripts/controllers/issuesOpenedController.js"></script>
         <script src="scripts/factories/issuesFactory.js"></script>
     </head>
 

--- a/git-technetium/public/partials/issues_opened.partial.html
+++ b/git-technetium/public/partials/issues_opened.partial.html
@@ -9,9 +9,10 @@
 <table>
     <tr>
         <th>Title</th>
+        <th>Issues Opened</th>
     </tr>
     <tr data-ng-repeat="contributor in pageData">
         <td>{{ contributor.name }}</td>
-        <td>{{ contributor.issues }}</td>
+        <td>{{ contributor.issues_opened }}</td>
     </tr>
 </table>

--- a/git-technetium/public/partials/issues_opened.partial.html
+++ b/git-technetium/public/partials/issues_opened.partial.html
@@ -1,0 +1,17 @@
+<form ng-submit="submitQuery()">
+    <p>
+        <strong>Repository Owner's Name: </strong><input type="text" ng-model="ownerName" required><br>
+        <strong>Repository Name: </strong><input type="text" ng-model="repoName" required><br>
+        <button type="submit">Get Issues Opened Per Contributor</button>
+    </p>
+</form>
+
+<table>
+    <tr>
+        <th>Title</th>
+    </tr>
+    <tr data-ng-repeat="contributor in pageData">
+        <td>{{ contributor.name }}</td>
+        <td>{{ contributor.issues }}</td>
+    </tr>
+</table>

--- a/git-technetium/public/scripts/app.js
+++ b/git-technetium/public/scripts/app.js
@@ -20,5 +20,13 @@ var gitApp = angular.module('gitApp', [
             data: {
                 pageTitle: 'Issues'
             }
+        })
+        .state('issues_opened', {
+            url: '/issues_opened',
+            templateUrl: 'partials/issues_opened.partial.html',
+            controller: 'issuesOpenedController',
+            data: {
+                pageTitle: 'Issues Opened Per Contributor'
+            }
         });
 });

--- a/git-technetium/public/scripts/controllers/issuesOpenedController.js
+++ b/git-technetium/public/scripts/controllers/issuesOpenedController.js
@@ -1,0 +1,11 @@
+'use strict';
+
+gitApp.controller('issuesOpenedController', function($scope, issuesOpenedFactory) {
+    $scope.pageData = [];
+
+    $scope.submitQuery = function() {
+        $scope.pageData = issuesOpenedFactory.get($scope.ownerName, $scope.repoName).success(function(data) {
+            $scope.pageData = data;
+        });
+    }
+});

--- a/git-technetium/public/scripts/factories/issuesFactory.js
+++ b/git-technetium/public/scripts/factories/issuesFactory.js
@@ -1,3 +1,7 @@
+/**
+ *  Factory for getting issue titles in a repository.
+ */
+
 'use strict';
 
 gitApp.factory('issuesFactory', function($http) {

--- a/git-technetium/public/scripts/factories/issuesOpenedFactory.js
+++ b/git-technetium/public/scripts/factories/issuesOpenedFactory.js
@@ -1,0 +1,16 @@
+'use strict';
+
+gitApp.factory('issuesOpenedFactory', function($http) {
+    return {
+        get: function(ownerName, repoName) {
+            return $http({
+                url: '/api/issues_opened',
+                method: 'GET',
+                params: {
+                    ownerName: ownerName,
+                    repoName: repoName
+                }
+            });
+        }
+    };
+});

--- a/git-technetium/public/scripts/factories/issuesOpenedFactory.js
+++ b/git-technetium/public/scripts/factories/issuesOpenedFactory.js
@@ -1,3 +1,7 @@
+/**
+ *  Factory for getting the number of opened issues per contributor in a repository.
+ */
+
 'use strict';
 
 gitApp.factory('issuesOpenedFactory', function($http) {

--- a/git-technetium/routes.js
+++ b/git-technetium/routes.js
@@ -27,4 +27,16 @@ module.exports = function(router, request) {
             }
         });
     });
+
+    router.get('/issues_opened', function(req, res) {
+        request({
+            url: 'https://api.github.com/repos/' + req.query.ownerName + '/' + req.query.repoName + '/issues?state=all',
+            headers: { 'user-agent': 'git-technetium' },
+            json: true
+        }, function(error, response, body) {
+            if(!error && response.statusCode === 200) {
+                res.send(body);
+            }
+        });
+    });
 }

--- a/git-technetium/routes.js
+++ b/git-technetium/routes.js
@@ -10,6 +10,13 @@ module.exports = function(router, request) {
         });
     });
 
+    /**
+     *  Precondition:
+     *      ownerName (string): The owner username of the target repository
+     *      repoName (string): The target repository name
+     *  Postcondition:
+     *      An array, where each element contains the title of an issue in the repository
+    **/
     router.get('/issues', function(req, res) {
         request({
             url: 'https://api.github.com/repos/' + req.query.ownerName + '/' + req.query.repoName + '/issues?state=all',
@@ -28,6 +35,15 @@ module.exports = function(router, request) {
         });
     });
 
+    /**
+     *  Precondition:
+     *      ownerName (string): The owner username of the target repository
+     *      repoName (string): The target repository name
+     *  Postcondition:
+     *      An array of objects, where each object contains the following properties:
+     *          name (string): The contributor username
+     *          issues_opened (string): The number of issues opened by the respective contributor
+    **/
     router.get('/issues_opened', function(req, res) {
         request({
             url: 'https://api.github.com/repos/' + req.query.ownerName + '/' + req.query.repoName + '/contributors',

--- a/git-technetium/routes.js
+++ b/git-technetium/routes.js
@@ -30,12 +30,43 @@ module.exports = function(router, request) {
 
     router.get('/issues_opened', function(req, res) {
         request({
-            url: 'https://api.github.com/repos/' + req.query.ownerName + '/' + req.query.repoName + '/issues?state=all',
+            url: 'https://api.github.com/repos/' + req.query.ownerName + '/' + req.query.repoName + '/contributors',
             headers: { 'user-agent': 'git-technetium' },
             json: true
         }, function(error, response, body) {
             if(!error && response.statusCode === 200) {
-                res.send(body);
+                var contributors = [];
+                for(var contributorIndex = 0; contributorIndex < body.length; contributorIndex++){
+                    contributors.push(body[contributorIndex].login);
+                }
+
+                var contributorIssuesOpened = [];
+                for(var contributorIndex = 0; contributorIndex < contributors.length; contributorIndex++) {
+                    contributorIssuesOpened.push({
+                        'name': contributors[contributorIndex],
+                        'issues_opened': 0
+                    });
+                }
+
+                request({
+                    url: 'https://api.github.com/repos/' + req.query.ownerName + '/' + req.query.repoName + '/issues?state=all',
+                    headers: { 'user-agent': 'git-technetium' },
+                    json: true
+                }, function(error, response, body) {
+                    if(!error && response.statusCode === 200) {
+                        for(var issueIndex = 0; issueIndex < body.length; issueIndex++) {
+                            if(!body[issueIndex].pull_request) {
+                                for(var contributorIndex = 0; contributorIndex < contributorIssuesOpened.length; contributorIndex++) {
+                                    if(body[issueIndex].user.login === contributorIssuesOpened[contributorIndex].name) {
+                                        contributorIssuesOpened[contributorIndex].issues_opened++;
+                                    }
+                                }
+                            }
+                        }
+
+                        res.send(contributorIssuesOpened);
+                    }
+                });
             }
         });
     });

--- a/notes/tasks.txt
+++ b/notes/tasks.txt
@@ -144,7 +144,7 @@ contributor.
 |
 + - - Create controller for handling issues opened data on client................[ X ]
 | 
-+ - - Create factory for getting data on client from server......................[   ]
++ - - Create factory for getting data on client from server......................[ X ]
 |
 + - - Create partial for displaying issues opened data on client.................[ X ]
 

--- a/notes/tasks.txt
+++ b/notes/tasks.txt
@@ -146,7 +146,7 @@ contributor.
 | 
 + - - Create factory for getting data on client from server......................[   ]
 |
-+ - - Create partial for displaying issues opened data on client.................[   ]
++ - - Create partial for displaying issues opened data on client.................[ X ]
 
 
 

--- a/notes/tasks.txt
+++ b/notes/tasks.txt
@@ -140,7 +140,7 @@ contributor.
 
 + - - Create server route for querying issues opened.............................[ X ]
 |     |
-|     + - - Parse data before sending to client..................................[   ]
+|     + - - Parse data before sending to client..................................[ X ]
 |
 + - - Create controller for handling issues opened data on client................[ X ]
 | 

--- a/notes/tasks.txt
+++ b/notes/tasks.txt
@@ -142,7 +142,7 @@ contributor.
 |     |
 |     + - - Parse data before sending to client..................................[   ]
 |
-+ - - Create controller for handling issues opened data on client................[   ]
++ - - Create controller for handling issues opened data on client................[ X ]
 | 
 + - - Create factory for getting data on client from server......................[   ]
 |

--- a/notes/tasks.txt
+++ b/notes/tasks.txt
@@ -138,7 +138,7 @@ This task involves creating a link that the user can click which will
 return a list of the number of issues opened in a repository by each
 contributor.
 
-+ - - Create server route for querying issues opened.............................[   ]
++ - - Create server route for querying issues opened.............................[ X ]
 |     |
 |     + - - Parse data before sending to client..................................[   ]
 |


### PR DESCRIPTION
This pull request addresses the following issues:
- #16: Create server route for querying issues opened per contributor
- #17: Parse issues opened per contributor data before sending to client
- #18: Create controller for handling issues opened per contributor data on client
- #19: Create factory for getting issues opened per contributor data on client from server
- #20: Create partial for displaying issues opened per contributor data on client

The number of issues opened per contributor page is located at `/#/issues_opened` URL in the browser which hooks to the `/api/issues_opened` endpoint on the server. User must specify the exact repository owner and repository name (case insensitive) before the page displays the number of issues opened per contributor for the repository.
