### PR TITLE
Completed task: "Number of Issues Assigned Per Contributor".

### DIFF
--- a/git-technetium/public/index.html
+++ b/git-technetium/public/index.html
@@ -16,6 +16,7 @@
         <script src="scripts/controllers/basicController.js"></script>
         <script src="scripts/controllers/issuesController.js"></script>
         <script src="scripts/controllers/issuesOpenedController.js"></script>
+        <script src="scripts/controllers/issuesAssignedController.js"></script>
         <script src="scripts/controllers/commitsController.js"></script>
         <script src="scripts/controllers/commitCommentsController.js"></script>
         <script src="scripts/controllers/pullsController.js"></script>
@@ -23,6 +24,7 @@
         <!-- FACTORIES -->
         <script src="scripts/factories/issuesFactory.js"></script>
         <script src="scripts/factories/issuesOpenedFactory.js"></script>
+        <script src="scripts/factories/issuesAssignedFactory.js"></script>
         <script src="scripts/factories/commitsFactory.js"></script>
         <script src="scripts/factories/commitCommentsFactory.js"></script>
         <script src="scripts/factories/pullsFactory.js"></script>

--- a/git-technetium/public/partials/issues_assigned.partial.html
+++ b/git-technetium/public/partials/issues_assigned.partial.html
@@ -2,17 +2,17 @@
     <p>
         <strong>Repository Owner's Name: </strong><input type="text" ng-model="ownerName" required><br>
         <strong>Repository Name: </strong><input type="text" ng-model="repoName" required><br>
-        <button type="submit">Get Issues Opened Per Contributor</button>
+        <button type="submit">Get Issues Assigned Per Contributor</button>
     </p>
 </form>
 
 <table>
     <tr>
         <th>Contributor Name</th>
-        <th>Issues Opened</th>
+        <th>Issues Assigned</th>
     </tr>
     <tr data-ng-repeat="contributor in pageData">
         <td>{{ contributor.name }}</td>
-        <td>{{ contributor.issues_opened }}</td>
+        <td>{{ contributor.issues_assigned }}</td>
     </tr>
 </table>

--- a/git-technetium/public/scripts/app.js
+++ b/git-technetium/public/scripts/app.js
@@ -29,6 +29,14 @@ var gitApp = angular.module('gitApp', [
                 pageTitle: 'Issues Opened Per Contributor'
             }
         })
+        .state('issues_assigned', {
+            url: '/issues_assigned',
+            templateUrl: 'partials/issues_assigned.partial.html',
+            controller: 'issuesAssignedController',
+            data: {
+                pageTitle: 'Issues Assigned Per Contributor'
+            }
+        })
         .state('commits', {
             url: '/commits',
             templateUrl: 'partials/commits.partial.html',

--- a/git-technetium/public/scripts/controllers/issuesAssignedController.js
+++ b/git-technetium/public/scripts/controllers/issuesAssignedController.js
@@ -1,0 +1,11 @@
+'use strict';
+
+gitApp.controller('issuesAssignedController', function($scope, issuesAssignedFactory) {
+    $scope.pageData = [];
+
+    $scope.submitQuery = function() {
+        $scope.pageData = issuesAssignedFactory.get($scope.ownerName, $scope.repoName).success(function(data) {
+            $scope.pageData = data;
+        });
+    }
+});

--- a/git-technetium/public/scripts/factories/issuesAssignedFactory.js
+++ b/git-technetium/public/scripts/factories/issuesAssignedFactory.js
@@ -1,0 +1,20 @@
+/**
+ *  Factory for getting the number of assigned issues per contributor in a repository.
+ */
+
+'use strict';
+
+gitApp.factory('issuesAssignedFactory', function($http) {
+    return {
+        get: function(ownerName, repoName) {
+            return $http({
+                url: '/api/issues_assigned',
+                method: 'GET',
+                params: {
+                    ownerName: ownerName,
+                    repoName: repoName
+                }
+            });
+        }
+    };
+});

--- a/git-technetium/routes.js
+++ b/git-technetium/routes.js
@@ -87,14 +87,54 @@ module.exports = function(router, request) {
         });
     });
 
+    /**
+     *  Precondition:
+     *      ownerName (string): The owner username of the target repository
+     *      repoName (string): The target repository name
+     *  Postcondition:
+     *      An array of objects, where each object contains the following properties:
+     *          name (string): The contributor username
+     *          issues_opened (string): The number of issues assigned to the respective contributor
+    **/
     router.get('/issues_assigned', function(req, res) {
         request({
-            url: 'https://api.github.com/repos/' + req.query.ownerName + '/' + req.query.repoName + '/issues?state=all',
+            url: 'https://api.github.com/repos/' + req.query.ownerName + '/' + req.query.repoName + '/contributors',
             headers: { 'user-agent': 'git-technetium' },
             json: true
         }, function(error, response, body) {
             if(!error && response.statusCode === 200) {
-                res.send(body);
+                var contributors = [];
+                for(var contributorIndex = 0; contributorIndex < body.length; contributorIndex++){
+                    contributors.push(body[contributorIndex].login);
+                }
+
+                var contributorIssuesAssigned = [];
+                for(var contributorIndex = 0; contributorIndex < contributors.length; contributorIndex++) {
+                    contributorIssuesAssigned.push({
+                        'name': contributors[contributorIndex],
+                        'issues_assigned': 0
+                    });
+                }
+
+                request({
+                    url: 'https://api.github.com/repos/' + req.query.ownerName + '/' + req.query.repoName + '/issues?state=all',
+                    headers: { 'user-agent': 'git-technetium' },
+                    json: true
+                }, function(error, response, body) {
+                    if(!error && response.statusCode === 200) {
+                        for(var issueIndex = 0; issueIndex < body.length; issueIndex++) {
+                            if(!body[issueIndex].pull_request) {
+                                for(var contributorIndex = 0; contributorIndex < contributorIssuesAssigned.length; contributorIndex++) {
+                                    if(body[issueIndex].assignee && body[issueIndex].assignee.login === contributorIssuesAssigned[contributorIndex].name) {
+                                        contributorIssuesAssigned[contributorIndex].issues_assigned++;
+                                    }
+                                }
+                            }
+                        }
+
+                        res.send(contributorIssuesAssigned);
+                    }
+                });
             }
         });
     });

--- a/git-technetium/routes.js
+++ b/git-technetium/routes.js
@@ -87,6 +87,18 @@ module.exports = function(router, request) {
         });
     });
 
+    router.get('/issues_assigned', function(req, res) {
+        request({
+            url: 'https://api.github.com/repos/' + req.query.ownerName + '/' + req.query.repoName + '/issues?state=all',
+            headers: { 'user-agent': 'git-technetium' },
+            json: true
+        }, function(error, response, body) {
+            if(!error && response.statusCode === 200) {
+                res.send(body);
+            }
+        });
+    });
+
     /**
       * Route to query total commits per contributor within a given repository.
       * params: owner, repo

--- a/notes/tasks.txt
+++ b/notes/tasks.txt
@@ -162,7 +162,7 @@ a given repository.
 |
 + - - Create controller for handling issues assigned data on client..............[ X ]
 | 
-+ - - Create factory for getting data on client from server......................[   ]
++ - - Create factory for getting data on client from server......................[ X ]
 |
 + - - Create partial for displaying issues assigned data on client...............[ X ]
 

--- a/notes/tasks.txt
+++ b/notes/tasks.txt
@@ -156,7 +156,7 @@ This task involves creating a link that the user can click which will
 return a list of the number of issues assigned to each contributor in
 a given repository. 
 
-+ - - Create server route for querying issues assigned...........................[   ]
++ - - Create server route for querying issues assigned...........................[ X ]
 |     |
 |     + - - Parse data before sending to client..................................[   ]
 |

--- a/notes/tasks.txt
+++ b/notes/tasks.txt
@@ -160,7 +160,7 @@ a given repository.
 |     |
 |     + - - Parse data before sending to client..................................[   ]
 |
-+ - - Create controller for handling issues assigned data on client..............[   ]
++ - - Create controller for handling issues assigned data on client..............[ X ]
 | 
 + - - Create factory for getting data on client from server......................[   ]
 |

--- a/notes/tasks.txt
+++ b/notes/tasks.txt
@@ -164,7 +164,7 @@ a given repository.
 | 
 + - - Create factory for getting data on client from server......................[   ]
 |
-+ - - Create partial for displaying issues assigned data on client...............[   ]
++ - - Create partial for displaying issues assigned data on client...............[ X ]
 
 
 

--- a/notes/tasks.txt
+++ b/notes/tasks.txt
@@ -158,7 +158,7 @@ a given repository.
 
 + - - Create server route for querying issues assigned...........................[ X ]
 |     |
-|     + - - Parse data before sending to client..................................[   ]
+|     + - - Parse data before sending to client..................................[ X ]
 |
 + - - Create controller for handling issues assigned data on client..............[ X ]
 | 


### PR DESCRIPTION
This pull request addresses the following issues:
- #36: Create server route for querying number of issues assigned per contributor
- #37: Parse number of issues assigned per contributor data before sending to client
- #38: Create controller for handling number of issues assigned per contributor data on client
- #39: Create factory for getting number of issues assigned per contributor data on client from server
- #40: Create partial for displaying number of issues assigned per contributor on client

The number of issues assigned per contributor page is located at `/#/issues_assigned` URL in the browser which hooks to the `/api/issues_assigned` endpoint on the server. User must specify the exact repository owner and repository name (case insensitive) before the page displays the number of issues assigned per contributor for the repository.
