### PR TITLE
Completed task: "Update Issues for Repository route to get all issue data".

### DIFF
--- a/git-technetium/public/partials/issues.partial.html
+++ b/git-technetium/public/partials/issues.partial.html
@@ -38,7 +38,7 @@
                                                     <td>{{ issue.number }}</td>
                                                     <td><a ng-href="http://github.com/DrkSephy/git-technetium/issues/{{ issue.number }}">{{ issue.title }}</a></td>
                                                     <td>{{ issue.state }}</td>
-                                                    <td>{{ issue.creator }}</td>
+                                                    <td><a ng-href="http://github.com/{{ issue.creator }}">{{ issue.creator }}</a></td>
                                                     <td><a ng-href="http://github.com/{{ issue.assignee }}">{{ issue.assignee }}</a></td>
                                                 </tr>
                                             </tbody>

--- a/git-technetium/public/partials/issues.partial.html
+++ b/git-technetium/public/partials/issues.partial.html
@@ -29,6 +29,7 @@
                                                     <th class="header">#</th>
                                                     <th class="header">Title</th>
                                                     <th class="header">State</th>
+                                                    <th class="header">Opened by</th>
                                                     <th class="header">Assigned to</th>
                                                 </tr>
                                             </thead>
@@ -37,6 +38,7 @@
                                                     <td>{{ issue.number }}</td>
                                                     <td><a ng-href="http://github.com/DrkSephy/git-technetium/issues/{{ issue.number }}">{{ issue.title }}</a></td>
                                                     <td>{{ issue.state }}</td>
+                                                    <td>{{ issue.creator }}</td>
                                                     <td><a ng-href="http://github.com/{{ issue.assignee }}">{{ issue.assignee }}</a></td>
                                                 </tr>
                                             </tbody>

--- a/git-technetium/public/partials/issues.partial.html
+++ b/git-technetium/public/partials/issues.partial.html
@@ -28,12 +28,14 @@
                                                 <tr>
                                                     <th class="header">#</th>
                                                     <th class="header">Title</th>
+                                                    <th class="header">State</th>
                                                 </tr>
                                             </thead>
                                             <tbody>
                                                 <tr data-ng-repeat="issue in pageData">
                                                     <td>{{ issue.number }}</td>
                                                     <td>{{ issue.title }}</td>
+                                                    <td>{{ issue.state }}</td>
                                                 </tr>
                                             </tbody>
                                         </table>

--- a/git-technetium/public/partials/issues.partial.html
+++ b/git-technetium/public/partials/issues.partial.html
@@ -35,7 +35,7 @@
                                             <tbody>
                                                 <tr data-ng-repeat="issue in pageData">
                                                     <td>{{ issue.number }}</td>
-                                                    <td>{{ issue.title }}</td>
+                                                    <td><a ng-href="http://github.com/DrkSephy/git-technetium/issues/{{ issue.number }}">{{ issue.title }}</a></td>
                                                     <td>{{ issue.state }}</td>
                                                     <td>{{ issue.assignee }}</td>
                                                 </tr>

--- a/git-technetium/public/partials/issues.partial.html
+++ b/git-technetium/public/partials/issues.partial.html
@@ -26,12 +26,14 @@
                                         <table class="table table-bordered table-hover table-striped tablesorter">
                                             <thead>
                                                 <tr>
-                                                    <th class="header">Issue Title</th>
+                                                    <th class="header">#</th>
+                                                    <th class="header">Title</th>
                                                 </tr>
                                             </thead>
                                             <tbody>
-                                                <tr data-ng-repeat="issueTitle in pageData">
-                                                    <td>{{ issueTitle }}</td>
+                                                <tr data-ng-repeat="issue in pageData">
+                                                    <td>{{ issue.number }}</td>
+                                                    <td>{{ issue.title }}</td>
                                                 </tr>
                                             </tbody>
                                         </table>

--- a/git-technetium/public/partials/issues.partial.html
+++ b/git-technetium/public/partials/issues.partial.html
@@ -37,7 +37,7 @@
                                                     <td>{{ issue.number }}</td>
                                                     <td><a ng-href="http://github.com/DrkSephy/git-technetium/issues/{{ issue.number }}">{{ issue.title }}</a></td>
                                                     <td>{{ issue.state }}</td>
-                                                    <td>{{ issue.assignee }}</td>
+                                                    <td><a ng-href="http://github.com/{{ issue.assignee }}">{{ issue.assignee }}</a></td>
                                                 </tr>
                                             </tbody>
                                         </table>

--- a/git-technetium/public/partials/issues.partial.html
+++ b/git-technetium/public/partials/issues.partial.html
@@ -29,6 +29,7 @@
                                                     <th class="header">#</th>
                                                     <th class="header">Title</th>
                                                     <th class="header">State</th>
+                                                    <th class="header">Assigned to</th>
                                                 </tr>
                                             </thead>
                                             <tbody>
@@ -36,6 +37,7 @@
                                                     <td>{{ issue.number }}</td>
                                                     <td>{{ issue.title }}</td>
                                                     <td>{{ issue.state }}</td>
+                                                    <td>{{ issue.assignee }}</td>
                                                 </tr>
                                             </tbody>
                                         </table>

--- a/git-technetium/routes.js
+++ b/git-technetium/routes.js
@@ -15,7 +15,12 @@ module.exports = function(router, request, async, CLIENT_ID, CLIENT_SECRET) {
      *      ownerName (string): The owner username of the target repository
      *      repoName  (string): The target repository name
      *  Postcondition:
-     *      An array, where each element contains the title of an issue in the repository
+     *      An array of objects such that each object contains the following:
+     *          number   (integer): The number of an issue in the repository
+     *          title    (string) : The title of an issue in the repository
+     *          state    (string) : The state (open, closed) of an issue in the repository
+     *          creator  (string) : The username of the person who opened the issue
+     *          assignee (string) : The username of the person who was assigned the issue
     **/
     router.get('/issues', function(req, res) {
         var issueData = [];

--- a/git-technetium/routes.js
+++ b/git-technetium/routes.js
@@ -24,13 +24,17 @@ module.exports = function(router, request, async, CLIENT_ID, CLIENT_SECRET) {
             json: true
         }, function(error, response, body) {
             if(!error && response.statusCode === 200) {
-                var issueTitles = [];
+                var issueData = [];
                 for(var issueIndex = 0; issueIndex < body.length; issueIndex++) {
                     if(!body[issueIndex].pull_request) {
-                        issueTitles.push(body[issueIndex].title);
+                        issueData.push({
+                            number: body[issueIndex].number,
+                            title: body[issueIndex].title,
+
+                        });
                     }
                 }
-                res.send(issueTitles);
+                res.send(issueData);
             }
         });
     });

--- a/git-technetium/routes.js
+++ b/git-technetium/routes.js
@@ -18,27 +18,35 @@ module.exports = function(router, request, async, CLIENT_ID, CLIENT_SECRET) {
      *      An array, where each element contains the title of an issue in the repository
     **/
     router.get('/issues', function(req, res) {
-        request({
-            url: 'https://api.github.com/repos/' + req.query.owner + '/' + req.query.repo + '/issues?state=all' + '&' + 'client_id=' + CLIENT_ID + '&' + 'client_secret=' + CLIENT_SECRET,
-            headers: { 'user-agent': 'git-technetium' },
-            json: true
-        }, function(error, response, body) {
-            if(!error && response.statusCode === 200) {
-                var issueData = [];
-                for(var issueIndex = 0; issueIndex < body.length; issueIndex++) {
-                    if(!body[issueIndex].pull_request) {
-                        issueData.push({
-                            number: body[issueIndex].number,
-                            title: body[issueIndex].title,
-                            state: body[issueIndex].state,
-                            creator: body[issueIndex].user.login,
-                            assignee: body[issueIndex].assignee ? body[issueIndex].assignee.login : ''
-                        });
+        var issueData = [];
+        var getData = function(pageCounter) {
+            request({
+                url: 'https://api.github.com/repos/' + req.query.owner + '/' + req.query.repo + '/issues?state=all' + '&page=' + pageCounter + '&client_id=' + CLIENT_ID + '&' + 'client_secret=' + CLIENT_SECRET,
+                headers: { 'user-agent': 'git-technetium' },
+                json: true
+            }, function(error, response, body) {
+                if(!error && response.statusCode === 200) {
+                    for(var issueIndex = 0; issueIndex < body.length; issueIndex++) {
+                        if(!body[issueIndex].pull_request) {
+                            issueData.push({
+                                number: body[issueIndex].number,
+                                title: body[issueIndex].title,
+                                state: body[issueIndex].state,
+                                creator: body[issueIndex].user.login,
+                                assignee: body[issueIndex].assignee ? body[issueIndex].assignee.login : ''
+                            });
+                        }
+                    }
+
+                    if(body.length < 30) {
+                        res.send(issueData);
+                    } else {
+                        getData(pageCounter + 1);
                     }
                 }
-                res.send(issueData);
-            }
-        });
+            });
+        };
+        getData(1);
     });
 
     /**

--- a/git-technetium/routes.js
+++ b/git-technetium/routes.js
@@ -31,6 +31,7 @@ module.exports = function(router, request, async, CLIENT_ID, CLIENT_SECRET) {
                             number: body[issueIndex].number,
                             title: body[issueIndex].title,
                             state: body[issueIndex].state,
+                            assignee: body[issueIndex].assignee ? body[issueIndex].assignee.login : ''
                         });
                     }
                 }

--- a/git-technetium/routes.js
+++ b/git-technetium/routes.js
@@ -31,6 +31,7 @@ module.exports = function(router, request, async, CLIENT_ID, CLIENT_SECRET) {
                             number: body[issueIndex].number,
                             title: body[issueIndex].title,
                             state: body[issueIndex].state,
+                            creator: body[issueIndex].user.login,
                             assignee: body[issueIndex].assignee ? body[issueIndex].assignee.login : ''
                         });
                     }

--- a/git-technetium/routes.js
+++ b/git-technetium/routes.js
@@ -30,7 +30,7 @@ module.exports = function(router, request, async, CLIENT_ID, CLIENT_SECRET) {
                         issueData.push({
                             number: body[issueIndex].number,
                             title: body[issueIndex].title,
-
+                            state: body[issueIndex].state,
                         });
                     }
                 }

--- a/notes/tasks.txt
+++ b/notes/tasks.txt
@@ -61,7 +61,7 @@ of 30 datasets.
 |
 + - - Update Number of Issues Closed per Contributor route to get all data......[ X ]
 |
-+ - - Update Issues for Repository route to get all issue data..................[   ]
++ - - Update Issues for Repository route to get all issue data..................[ X ]
 
 #####################################################################################
 #               Tasks / Road map (Project Inception ~ August 9th, 2014)             #


### PR DESCRIPTION
This pull request addresses the following issue:
- #80: Update Issues for Repository route to get all issue data

The `/api/issues` endpoint will now return the list of **all** issues (excluding pull requests) in a repository largely thanks to @drksephy's implementation of asynchronous requests (#69).

In addition, the `/#/issues` route will now display the following:
- Issue number
- Issue title (and link to respective issue page on GitHub)
- Issue state (open, closed)
- Issue creator (and link to respective issue creator's profile)
- Issue assignee (and link to respective issue assignee's profile)
