### PR TITLE
Fixed bug with reports module.

### DIFF
--- a/git-technetium/public/scripts/controllers/reportController.js
+++ b/git-technetium/public/scripts/controllers/reportController.js
@@ -15,13 +15,13 @@ gitApp.controller('reportController', function($scope, commitsFactory, locFactor
     $scope.pullRequestCommentsData = [];
 
     // Stores the final result of allData
-    $scope.parsed = []; 
     var allData = [];
     
 
     $scope.submitQuery = function(){
         async.waterfall([
             function(callback){
+                $scope.parsed = [];
                 allData = [];
                 callback(null);
             },

--- a/git-technetium/public/scripts/controllers/reportController.js
+++ b/git-technetium/public/scripts/controllers/reportController.js
@@ -101,38 +101,40 @@ gitApp.controller('reportController', function($scope, commitsFactory, locFactor
                     parsedData.push(contributorData);
                     for(var arrayIndex = 0; arrayIndex < allData.length; arrayIndex++){
                         for(var attributeIndex = 0; attributeIndex < allData[arrayIndex].length; attributeIndex++){
-                            if(typeof(allData[arrayIndex][contributorIndex].name) !== "undefined"){
-                                parsedData[contributorIndex]['name'] = allData[arrayIndex][contributorIndex].name;
-                            }
-                            if(typeof(allData[arrayIndex][contributorIndex].commits) !== "undefined"){
-                                parsedData[contributorIndex]['commits'] = allData[arrayIndex][contributorIndex].commits;
-                            }
-                            if(typeof(allData[arrayIndex][contributorIndex].loc_added) !== "undefined"){
-                                parsedData[contributorIndex]['loc_added'] = allData[arrayIndex][contributorIndex].loc_added;
-                            }
-                            if(typeof(allData[arrayIndex][contributorIndex].loc_deleted) !== "undefined"){
-                                parsedData[contributorIndex]['loc_deleted'] = allData[arrayIndex][contributorIndex].loc_deleted;
-                            }
-                            if(typeof(allData[arrayIndex][contributorIndex].commit_comments) !== "undefined"){
-                                parsedData[contributorIndex]['commit_comments'] = allData[arrayIndex][contributorIndex].commit_comments;
-                            }
-                            if(typeof(allData[arrayIndex][contributorIndex].issues_assigned) !== "undefined"){
-                                parsedData[contributorIndex]['issues_assigned'] = allData[arrayIndex][contributorIndex].issues_assigned;
-                            }
-                            if(typeof(allData[arrayIndex][contributorIndex].issues_closed) !== "undefined"){
-                                parsedData[contributorIndex]['issues_closed'] = allData[arrayIndex][contributorIndex].issues_closed;
-                            }
-                            if(typeof(allData[arrayIndex][contributorIndex].issues_opened) !== "undefined"){
-                                parsedData[contributorIndex]['issues_opened'] = allData[arrayIndex][contributorIndex].issues_opened;
-                            }
-                            if(typeof(allData[arrayIndex][contributorIndex].issue_comments) !== "undefined"){
-                                parsedData[contributorIndex]['issue_comments'] = allData[arrayIndex][contributorIndex].issue_comments;
-                            }
-                            if(typeof(allData[arrayIndex][contributorIndex].total) !== "undefined"){
-                                parsedData[contributorIndex]['pull_requests'] = allData[arrayIndex][contributorIndex].total;
-                            }
-                            if(typeof(allData[arrayIndex][contributorIndex].comments) !== "undefined"){
-                                parsedData[contributorIndex]['pull_request_comments'] = allData[arrayIndex][contributorIndex].comments;
+                            if(typeof(allData[arrayIndex][contributorIndex]) !== "undefined"){
+                                if(typeof(allData[arrayIndex][contributorIndex].name) !== "undefined"){
+                                    parsedData[contributorIndex]['name'] = allData[arrayIndex][contributorIndex].name;
+                                }
+                                if(typeof(allData[arrayIndex][contributorIndex].commits) !== "undefined"){
+                                    parsedData[contributorIndex]['commits'] = allData[arrayIndex][contributorIndex].commits;
+                                }
+                                if(typeof(allData[arrayIndex][contributorIndex].loc_added) !== "undefined"){
+                                    parsedData[contributorIndex]['loc_added'] = allData[arrayIndex][contributorIndex].loc_added;
+                                }
+                                if(typeof(allData[arrayIndex][contributorIndex].loc_deleted) !== "undefined"){
+                                    parsedData[contributorIndex]['loc_deleted'] = allData[arrayIndex][contributorIndex].loc_deleted;
+                                }
+                                if(typeof(allData[arrayIndex][contributorIndex].commit_comments) !== "undefined"){
+                                    parsedData[contributorIndex]['commit_comments'] = allData[arrayIndex][contributorIndex].commit_comments;
+                                }
+                                if(typeof(allData[arrayIndex][contributorIndex].issues_assigned) !== "undefined"){
+                                    parsedData[contributorIndex]['issues_assigned'] = allData[arrayIndex][contributorIndex].issues_assigned;
+                                }
+                                if(typeof(allData[arrayIndex][contributorIndex].issues_closed) !== "undefined"){
+                                    parsedData[contributorIndex]['issues_closed'] = allData[arrayIndex][contributorIndex].issues_closed;
+                                }
+                                if(typeof(allData[arrayIndex][contributorIndex].issues_opened) !== "undefined"){
+                                    parsedData[contributorIndex]['issues_opened'] = allData[arrayIndex][contributorIndex].issues_opened;
+                                }
+                                if(typeof(allData[arrayIndex][contributorIndex].issue_comments) !== "undefined"){
+                                    parsedData[contributorIndex]['issue_comments'] = allData[arrayIndex][contributorIndex].issue_comments;
+                                }
+                                if(typeof(allData[arrayIndex][contributorIndex].total) !== "undefined"){
+                                    parsedData[contributorIndex]['pull_requests'] = allData[arrayIndex][contributorIndex].total;
+                                }
+                                if(typeof(allData[arrayIndex][contributorIndex].comments) !== "undefined"){
+                                    parsedData[contributorIndex]['pull_request_comments'] = allData[arrayIndex][contributorIndex].comments;
+                                }
                             }
                         }
                     }

--- a/git-technetium/public/scripts/controllers/reportController.js
+++ b/git-technetium/public/scripts/controllers/reportController.js
@@ -22,6 +22,10 @@ gitApp.controller('reportController', function($scope, commitsFactory, locFactor
     $scope.submitQuery = function(){
         async.waterfall([
             function(callback){
+                allData = [];
+                callback(null);
+            },
+            function(callback){
                 $scope.commitData = commitsFactory.get($scope.owner, $scope.repo).success(function(data){
                     allData.push(data);
                     callback(null);
@@ -101,40 +105,38 @@ gitApp.controller('reportController', function($scope, commitsFactory, locFactor
                     parsedData.push(contributorData);
                     for(var arrayIndex = 0; arrayIndex < allData.length; arrayIndex++){
                         for(var attributeIndex = 0; attributeIndex < allData[arrayIndex].length; attributeIndex++){
-                            if(typeof(allData[arrayIndex][contributorIndex]) !== "undefined"){
-                                if(typeof(allData[arrayIndex][contributorIndex].name) !== "undefined"){
-                                    parsedData[contributorIndex]['name'] = allData[arrayIndex][contributorIndex].name;
-                                }
-                                if(typeof(allData[arrayIndex][contributorIndex].commits) !== "undefined"){
-                                    parsedData[contributorIndex]['commits'] = allData[arrayIndex][contributorIndex].commits;
-                                }
-                                if(typeof(allData[arrayIndex][contributorIndex].loc_added) !== "undefined"){
-                                    parsedData[contributorIndex]['loc_added'] = allData[arrayIndex][contributorIndex].loc_added;
-                                }
-                                if(typeof(allData[arrayIndex][contributorIndex].loc_deleted) !== "undefined"){
-                                    parsedData[contributorIndex]['loc_deleted'] = allData[arrayIndex][contributorIndex].loc_deleted;
-                                }
-                                if(typeof(allData[arrayIndex][contributorIndex].commit_comments) !== "undefined"){
-                                    parsedData[contributorIndex]['commit_comments'] = allData[arrayIndex][contributorIndex].commit_comments;
-                                }
-                                if(typeof(allData[arrayIndex][contributorIndex].issues_assigned) !== "undefined"){
-                                    parsedData[contributorIndex]['issues_assigned'] = allData[arrayIndex][contributorIndex].issues_assigned;
-                                }
-                                if(typeof(allData[arrayIndex][contributorIndex].issues_closed) !== "undefined"){
-                                    parsedData[contributorIndex]['issues_closed'] = allData[arrayIndex][contributorIndex].issues_closed;
-                                }
-                                if(typeof(allData[arrayIndex][contributorIndex].issues_opened) !== "undefined"){
-                                    parsedData[contributorIndex]['issues_opened'] = allData[arrayIndex][contributorIndex].issues_opened;
-                                }
-                                if(typeof(allData[arrayIndex][contributorIndex].issue_comments) !== "undefined"){
-                                    parsedData[contributorIndex]['issue_comments'] = allData[arrayIndex][contributorIndex].issue_comments;
-                                }
-                                if(typeof(allData[arrayIndex][contributorIndex].total) !== "undefined"){
-                                    parsedData[contributorIndex]['pull_requests'] = allData[arrayIndex][contributorIndex].total;
-                                }
-                                if(typeof(allData[arrayIndex][contributorIndex].comments) !== "undefined"){
-                                    parsedData[contributorIndex]['pull_request_comments'] = allData[arrayIndex][contributorIndex].comments;
-                                }
+                            if(typeof(allData[arrayIndex][contributorIndex].name) !== "undefined"){
+                                parsedData[contributorIndex]['name'] = allData[arrayIndex][contributorIndex].name;
+                            }
+                            if(typeof(allData[arrayIndex][contributorIndex].commits) !== "undefined"){
+                                parsedData[contributorIndex]['commits'] = allData[arrayIndex][contributorIndex].commits;
+                            }
+                            if(typeof(allData[arrayIndex][contributorIndex].loc_added) !== "undefined"){
+                                parsedData[contributorIndex]['loc_added'] = allData[arrayIndex][contributorIndex].loc_added;
+                            }
+                            if(typeof(allData[arrayIndex][contributorIndex].loc_deleted) !== "undefined"){
+                                parsedData[contributorIndex]['loc_deleted'] = allData[arrayIndex][contributorIndex].loc_deleted;
+                            }
+                            if(typeof(allData[arrayIndex][contributorIndex].commit_comments) !== "undefined"){
+                                parsedData[contributorIndex]['commit_comments'] = allData[arrayIndex][contributorIndex].commit_comments;
+                            }
+                            if(typeof(allData[arrayIndex][contributorIndex].issues_assigned) !== "undefined"){
+                                parsedData[contributorIndex]['issues_assigned'] = allData[arrayIndex][contributorIndex].issues_assigned;
+                            }
+                            if(typeof(allData[arrayIndex][contributorIndex].issues_closed) !== "undefined"){
+                                parsedData[contributorIndex]['issues_closed'] = allData[arrayIndex][contributorIndex].issues_closed;
+                            }
+                            if(typeof(allData[arrayIndex][contributorIndex].issues_opened) !== "undefined"){
+                                parsedData[contributorIndex]['issues_opened'] = allData[arrayIndex][contributorIndex].issues_opened;
+                            }
+                            if(typeof(allData[arrayIndex][contributorIndex].issue_comments) !== "undefined"){
+                                parsedData[contributorIndex]['issue_comments'] = allData[arrayIndex][contributorIndex].issue_comments;
+                            }
+                            if(typeof(allData[arrayIndex][contributorIndex].total) !== "undefined"){
+                                parsedData[contributorIndex]['pull_requests'] = allData[arrayIndex][contributorIndex].total;
+                            }
+                            if(typeof(allData[arrayIndex][contributorIndex].comments) !== "undefined"){
+                                parsedData[contributorIndex]['pull_request_comments'] = allData[arrayIndex][contributorIndex].comments;
                             }
                         }
                     }


### PR DESCRIPTION
This pull request addresses the following issue:
- #86: Bug with reports module

The problem is two-parts: one being the caching of variables in the view and the other being the improper cleanup of variables on new requests. When the first request is sent, the variables are initiated from a clean slate and constructs the dataset without problems. However, when a subsequent request is sent, some of the data from the first request still remains in cache and proceeds to rebuild the new dataset with some of the previous request's data inside. This causes misalignment in the `allData` array, which in turn, results in the undefined error as seen in the issue.

The fix was to add an initial function to the `async.waterfall` with the purpose to reset the old dataset back to its initial empty state. Thus, it addresses both of the aforementioned problems by overwriting the cached variables and provide proper cleanup whenever a new request is sent.
